### PR TITLE
Fix occasional occurence of horizontal scrollbar

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -354,6 +354,7 @@
 
 body {
 	font-family: Arial, Helvetica, Sans-serif;
+	overflow-x: hidden;
 }
 
 img {


### PR DESCRIPTION
Looks like the animation is causing the body to overflow (_only horizontally_).
Adding the `overflow-x: hidden;` to `body` seems to fix the problem.